### PR TITLE
Add constraint names in the form genreated before Postgres 12.

### DIFF
--- a/Schema/app/003-app-role.blue.sql
+++ b/Schema/app/003-app-role.blue.sql
@@ -46,7 +46,7 @@ CREATE TRIGGER app_role_ledger_insert_trigger
 CREATE TABLE odin.app_user_role (
     app_id TEXT NOT NULL,
     identity_id TEXT NOT NULL,
-    FOREIGN KEY (app_id, identity_id)
+    CONSTRAINT app_user_role_app_id_fkey FOREIGN KEY (app_id, identity_id)
         REFERENCES odin.app_user (app_id, identity_id) MATCH SIMPLE
         ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE,
     role TEXT NOT NULL,
@@ -60,7 +60,7 @@ CREATE TABLE odin.app_user_role_ledger (
     reference text NOT NULL,
     app_id text NOT NULL,
     identity_id TEXT NOT NULL,
-    FOREIGN KEY (app_id, identity_id)
+    CONSTRAINT app_user_role_ledger_app_id_fkey FOREIGN KEY (app_id, identity_id)
         REFERENCES odin.app_user (app_id, identity_id) MATCH SIMPLE
         ON UPDATE NO ACTION ON DELETE NO ACTION DEFERRABLE,
     role TEXT NOT NULL,


### PR DESCRIPTION
It seems that the way the default constraint names are generated has been changed in Postgres 12. Given the names though, it looks more like a bug fix. In any case, it breaks the migrations.

The fix just explicitly puts in place the names used before PG 12.